### PR TITLE
Improve login window with Hackboot branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # db_ldlc
+
+This repository demonstrates a small Python GUI.
+Running `main.py` opens a mid-sized window that fades in to reveal a dark theme login form.
+The title **Hackboot** slides down before the username and password fields appear.
+
+## Requirements
+
+- Python 3
+- [ttkbootstrap](https://github.com/israel-dryer/ttkbootstrap) for a modern look
+
+## Usage
+
+Install the dependency and run the program:
+
+```bash
+pip install ttkbootstrap
+python main.py
+```
+
+Entering your credentials and pressing **Login** will display them in a simple dialog box.

--- a/login_gui.py
+++ b/login_gui.py
@@ -1,0 +1,35 @@
+import tkinter as tk
+from tkinter import messagebox
+
+
+def login():
+    username = entry_user.get()
+    password = entry_pass.get()
+    # In a real application you'd validate credentials here
+    messagebox.showinfo("Login", f"Username: {username}\nPassword: {password}")
+
+
+root = tk.Tk()
+root.title("Login")
+root.geometry("300x150")
+root.resizable(False, False)
+
+frame = tk.Frame(root, padx=10, pady=10)
+frame.pack(expand=True)
+
+label_user = tk.Label(frame, text="Username:")
+label_user.grid(row=0, column=0, sticky="e")
+
+entry_user = tk.Entry(frame)
+entry_user.grid(row=0, column=1, pady=5)
+
+label_pass = tk.Label(frame, text="Password:")
+label_pass.grid(row=1, column=0, sticky="e")
+
+entry_pass = tk.Entry(frame, show="*")
+entry_pass.grid(row=1, column=1, pady=5)
+
+btn_login = tk.Button(frame, text="Login", command=login)
+btn_login.grid(row=2, columnspan=2, pady=10)
+
+root.mainloop()

--- a/main.py
+++ b/main.py
@@ -1,0 +1,64 @@
+import ttkbootstrap as ttk
+from ttkbootstrap.constants import *
+from ttkbootstrap.dialogs import Messagebox
+
+
+def fade_in(window, interval=20, step=0.05, alpha=0.0):
+    """Gradually fade in the window for a smooth appearance."""
+    if alpha < 1.0:
+        window.attributes("-alpha", alpha)
+        window.after(interval, fade_in, window, interval, step, alpha + step)
+    else:
+        window.attributes("-alpha", 1.0)
+
+
+app = ttk.Window(themename="cyborg")
+app.title("Hackboot Login")
+app.geometry("500x300")
+app.resizable(False, False)
+app.attributes("-alpha", 0.0)
+
+
+# Create main frame
+container = ttk.Frame(app, padding=20)
+container.pack(expand=True, fill=BOTH)
+
+# Animated title
+title = ttk.Label(container, text="Hackboot", font=("Helvetica", 28, "bold"), bootstyle=INFO)
+
+def slide_title(y=-50):
+    if y < 20:
+        title.place(relx=0.5, y=y, anchor="n")
+        app.after(10, slide_title, y + 5)
+    else:
+        title.place(relx=0.5, y=20, anchor="n")
+
+title.place(relx=0.5, y=-50, anchor="n")
+
+# Login form
+form = ttk.Frame(container)
+form.place(relx=0.5, rely=0.45, anchor="center")
+
+lbl_user = ttk.Label(form, text="Username:")
+lbl_user.grid(row=0, column=0, sticky=E, pady=5, padx=5)
+entry_user = ttk.Entry(form, width=30)
+entry_user.grid(row=0, column=1, pady=5)
+
+lbl_pass = ttk.Label(form, text="Password:")
+lbl_pass.grid(row=1, column=0, sticky=E, pady=5, padx=5)
+entry_pass = ttk.Entry(form, show="*", width=30)
+entry_pass.grid(row=1, column=1, pady=5)
+
+
+def login():
+    username = entry_user.get()
+    password = entry_pass.get()
+    Messagebox.ok(f"Username: {username}\nPassword: {password}", title="Login")
+
+
+btn = ttk.Button(form, text="Login", bootstyle=SUCCESS, command=login)
+btn.grid(row=2, columnspan=2, pady=(15, 0))
+
+app.after(0, fade_in, app)
+app.after(200, slide_title)
+app.mainloop()


### PR DESCRIPTION
## Summary
- update README to describe Hackboot login UI demo
- redesign `main.py` with larger window and sliding Hackboot title

## Testing
- `python -m py_compile main.py login_gui.py`


------
https://chatgpt.com/codex/tasks/task_e_687d800d1adc8333aa47692e61357f47